### PR TITLE
Fix fit cell issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "tecnick.com/tcpdf",
+	"name": "tecnickcom/tcpdf",
 	"version": "6.2.14",
 	"homepage": "http://www.tcpdf.org/",
 	"type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "tecnickcom/tcpdf",
-	"version": "6.2.14",
+	"version": "6.2.15",
 	"homepage": "http://www.tcpdf.org/",
 	"type": "library",
 	"description": "TCPDF is a PHP class for generating PDF documents and barcodes.",

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -5832,7 +5832,7 @@ class TCPDF {
 			if ($fitcell) {
 				// ajust height values
 				$tobottom = ($this->h - $this->y - $this->bMargin - $this->cell_padding['T'] - $this->cell_padding['B']);
-				$h = $maxh = max(min($h, $tobottom), min($maxh, $tobottom));
+				$h = $maxh = min(min($h, $tobottom), min($maxh, $tobottom));
 			}
 			// vertical alignment
 			if ($maxh > 0) {


### PR DESCRIPTION
`MultiCell()` の挙動変更。

$fitcellの場合、line height または element height の大きい方の値を採用していたが、利用意図に沿って小さい方の値を採用する。